### PR TITLE
"Basset\Container::config()" undefined while using global compression.

### DIFF
--- a/classes/container.php
+++ b/classes/container.php
@@ -247,7 +247,7 @@ class Container {
 				{
 					if($group == 'styles')
 					{
-						$assets = Basset\Vendor\CSSCompress::process($assets, array('preserve_lines' => $this->config('compression.preserve_lines')));
+						$assets = Basset\Vendor\CSSCompress::process($assets, array('preserve_lines' => Config::get('compression.preserve_lines')));
 					}
 					elseif($group == 'scripts')
 					{


### PR DESCRIPTION
When using global compression in an Extended config, a "Call to undefined method Basset\Container::config()" is generated. Using the static method corrects this.

Additionally, it's the only line in which $this is used to attempt to read config setting.
