### PR TITLE
Fix "Class 'Basset\Bundle' not found" error when loading bundle assets

### DIFF
--- a/classes/container.php
+++ b/classes/container.php
@@ -1,6 +1,6 @@
 <?php namespace Basset;
 
-use File, Basset;
+use File, Basset, \Laravel\Bundle;
 
 class Container {
 


### PR DESCRIPTION
`\Basset\Container::directory()` tries to call `Basset::corrector()`, which fails in the `Basset` namespace.

> Fatal error: Class 'Basset\Bundle' not found in bundles/basset/classes/container.php on line 71
