### PR TITLE
Enable Browser Caching in Basset

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -34,5 +34,11 @@
 */
 Route::get('(:bundle)/(:all)', function()
 {
-	return Basset::compiled();
+	$headers = array(
+		'Cache-Control'	=> 'max-age='.(24*60*60).', public',
+		'Pragma'	=> 'cache',
+		'Last-Modified'	=> gmdate('D, d M Y H:i:s').' GMT'
+	);
+	
+	return Response::make(Basset::compiled(), 200, $headers);
 });


### PR DESCRIPTION
Basset returns the default cache-control:no-cache header set by laravel, which is very undesirable for static assets. This basically breaks all notions for browser (or cdn) caching.

The fix is as simple as defining a few headers that tell browsers (and pull zone cdn's) to store the resource for a fixed time. This change does exactly that. The caching period is set to one day. Potentially this setting can be moved to basset's config.
