### PR TITLE
Add global development option

### DIFF
--- a/config/basset.php
+++ b/config/basset.php
@@ -51,14 +51,14 @@ return array(
 	'compiling' => array(
 		/**
 		 * Compiled Directory
-		 * 
+		 *
 		 * The directory to save the compiled Basset files, ensure this directory is writeable.
 		 */
 		'directory' => Bundle::path('basset') . 'compiled',
 
 		/**
 		 * Recompile
-		 * 
+		 *
 		 * Sometimes you may wish to have assets recompiled every time, setting this option to true will
 		 * allow this. Don't forget to set it to false on a live website for maximum performance.
 		 */

--- a/config/basset.php
+++ b/config/basset.php
@@ -66,6 +66,11 @@ return array(
 	),
 
 	/**
+	 * Whether files should always be displayed in development mode or not
+	 */
+	'development' => false,
+
+	/**
 	 * Document Root
 	 *
 	 * The document root of the website in which the CSS files reside. If no document root is provided

--- a/libraries/core/asset.php
+++ b/libraries/core/asset.php
@@ -8,49 +8,49 @@ class Asset {
 
 	/**
 	 * Name of the asset.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $name;
 
 	/**
 	 * Path name of the asset.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $file;
 
 	/**
 	 * Asset dependencies.
-	 * 
+	 *
 	 * @var array
 	 */
 	public $dependencies = array();
 
 	/**
 	 * If the asset is external.
-	 * 
+	 *
 	 * @var bool
 	 */
 	public $external = false;
 
 	/**
 	 * Time the asset was updated.
-	 * 
+	 *
 	 * @var int
 	 */
 	public $updated = 0;
 
 	/**
 	 * Directory location of the asset.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $directory = null;
 
 	/**
 	 * URL to the asset.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $url = null;
@@ -76,7 +76,7 @@ class Asset {
 
 	/**
 	 * Checks if the asset exists within the given directory.
-	 * 
+	 *
 	 * @param  string  $directory
 	 * @return bool
 	 */
@@ -97,7 +97,7 @@ class Asset {
 				list($bundle, $file) = explode('::', $this->file);
 
 				$this->directory .= trim(Bundle::assets($bundle), '/');
-				
+
 				$this->file = $file;
 
 				$this->file = $file;
@@ -137,7 +137,7 @@ class Asset {
 
 	/**
 	 * If the asset is external or internal.
-	 * 
+	 *
 	 * @return bool
 	 */
 	public function external()
@@ -171,7 +171,7 @@ class Asset {
 		if(!$this->external() and $this->is('less') and $lessphp)
 		{
 			$less = new Vendor\lessc;
-			
+
 			$less->importDir = $this->directory;
 
 			$contents = $less->parse($contents);
@@ -188,7 +188,7 @@ class Asset {
 
 	/**
 	 * Returns the path to the asset or just the asset file if the asset is external.
-	 * 
+	 *
 	 * @return string
 	 */
 	protected function path()
@@ -198,7 +198,7 @@ class Asset {
 
 	/**
 	 * Checks if the asset is part of a group based on its extension.
-	 * 
+	 *
 	 * @param  string  $group
 	 * @return void
 	 */

--- a/libraries/core/basset.php
+++ b/libraries/core/basset.php
@@ -14,21 +14,21 @@ class Basset {
 
 	/**
 	 * Array of registered route containers.
-	 * 
+	 *
 	 * @var array
 	 */
 	public static $routes = array();
 
 	/**
 	 * Array of registered inline containers.
-	 * 
+	 *
 	 * @var array
 	 */
 	public static $inline = array();
 
 	/**
 	 * Register a new inline container.
-	 * 
+	 *
 	 * @param  string  $name
 	 */
 	public static function inline($name)
@@ -64,7 +64,7 @@ class Basset {
 
 	/**
 	 * Creates a new container to register assets or uses an already existing container.
-	 * 
+	 *
 	 * @param  string   $name
 	 * @param  string   $group
 	 * @param  Closure  $callback
@@ -84,7 +84,7 @@ class Basset {
 
 	/**
 	 * Shares an asset that can be later added without too much typing.
-	 * 
+	 *
 	 * @param  string  $name
 	 * @param  string  $file
 	 * @return void
@@ -96,7 +96,7 @@ class Basset {
 
 	/**
 	 * Generate a scripts route.
-	 * 
+	 *
 	 * @param  string   $name
 	 * @param  Closure  $callback
 	 * @return void
@@ -108,7 +108,7 @@ class Basset {
 
 	/**
 	 * Generate a styles route.
-	 * 
+	 *
 	 * @param  string   $name
 	 * @param  Closure  $callback
 	 * @return void
@@ -120,7 +120,7 @@ class Basset {
 
 	/**
 	 * Compiles assets for all registered containers.
-	 * 
+	 *
 	 * @return void
 	 */
 	public static function compile()
@@ -133,7 +133,7 @@ class Basset {
 
 	/**
 	 * Return the compiled output for a given container.
-	 * 
+	 *
 	 * @return string
 	 */
 	public static function compiled()
@@ -160,7 +160,7 @@ class Basset {
 
 	/**
 	 * Return the URL to the asset route container.
-	 * 
+	 *
 	 * @param  string  $route
 	 * @return string
 	 */

--- a/libraries/core/cache.php
+++ b/libraries/core/cache.php
@@ -6,35 +6,35 @@ class Cache {
 
 	/**
 	 * The route that the cached assets respond to.
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $route;
 
 	/**
 	 * If the cached copy is set to be forgotten.
-	 * 
+	 *
 	 * @var bool
 	 */
 	protected $forget;
 
 	/**
 	 * The name of the cached copy, also used for the compiled files.
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $name;
 
 	/**
 	 * The time the cached copy will be stored for.
-	 * 
+	 *
 	 * @var int
 	 */
 	public $time;
 
 	/**
 	 * Create a new Basset\Cache instance.
-	 * 
+	 *
 	 * @param  string  $route
 	 * @return void
 	 */

--- a/libraries/core/config.php
+++ b/libraries/core/config.php
@@ -42,11 +42,11 @@ class Config {
 	 */
 	public function __construct()
 	{
-		$this->config = array_merge(C::get('basset::basset'), array(
-			'caching'	  => array('forget' => false),
-			'inline'	  => false,
+		$this->config = array_merge(array(
+			'caching'     => array('forget' => false),
+			'inline'      => false,
 			'development' => false
-		), Config::$extend);
+		), C::get('basset::basset'), Config::$extend);
 	}
 
 	/**

--- a/libraries/core/config.php
+++ b/libraries/core/config.php
@@ -6,21 +6,21 @@ class Config {
 
 	/**
 	 * Array containing the extended configuration.
-	 * 
+	 *
 	 * @var array
 	 */
 	public static $extend = array();
 
 	/**
 	 * Array containing the configuration.
-	 * 
+	 *
 	 * @var array
 	 */
 	protected $config = array();
 
 	/**
 	 * Extend the configuration with a custom configuration file.
-	 * 
+	 *
 	 * @param  array  $extend
 	 * @return void
 	 */
@@ -37,7 +37,7 @@ class Config {
 
 	/**
 	 * Loads the config and merges in defaults and any extenders.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function __construct()
@@ -51,7 +51,7 @@ class Config {
 
 	/**
 	 * Get a config key from the config array.
-	 * 
+	 *
 	 * @param  string  $key
 	 * @return mixed
 	 */
@@ -62,7 +62,7 @@ class Config {
 
 	/**
 	 * Set a config key in the config array.
-	 * 
+	 *
 	 * @param  string  $key
 	 * @param  mixed   $value
 	 * @return void

--- a/libraries/core/container.php
+++ b/libraries/core/container.php
@@ -10,35 +10,35 @@ class Container {
 
 	/**
 	 * Array of shared assets.
-	 * 
+	 *
 	 * @var array
 	 */
 	public static $shared = array();
 
 	/**
 	 * The route the assets will be display on.
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $route;
 
 	/**
 	 * The group the assets belong to, either scripts or styles.
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $group;
 
 	/**
 	 * The cache object used to store the cached assets.
-	 * 
+	 *
 	 * @var object
 	 */
 	protected $cache;
 
 	/**
 	 * The array containing all the registered assets.
-	 * 
+	 *
 	 * @var array
 	 */
 	protected $assets = array(
@@ -48,21 +48,21 @@ class Container {
 
 	/**
 	 * The current directory to register assets from.
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $directory;
 
 	/**
 	 * The array of registered symlinks.
-	 * 
+	 *
 	 * @var array
 	 */
 	protected $symlinks = array();
 
 	/**
 	 * The array of configuration settings.
-	 * 
+	 *
 	 * @var array
 	 */
 	public $config = array();
@@ -157,7 +157,7 @@ class Container {
 
 	/**
 	 * Delete an asset from the container.
-	 * 
+	 *
 	 * @param  string  $name
 	 * @return object
 	 */
@@ -265,7 +265,7 @@ class Container {
 
 	/**
 	 * Compiles the scripts for the current container.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function scripts()
@@ -275,7 +275,7 @@ class Container {
 
 	/**
 	 * Compiles the styles for the current container.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function styles()
@@ -285,7 +285,7 @@ class Container {
 
 	/**
 	 * Prepares the assets for compiling.
-	 * 
+	 *
 	 * @param  string  $group
 	 * @return void
 	 */
@@ -419,7 +419,7 @@ class Container {
 
 	/**
 	 * Determines the group to be used.
-	 * 
+	 *
 	 * @return string
 	 */
 	protected function group()
@@ -560,7 +560,7 @@ class Container {
 
 	/**
 	 * Magic method for converting the object to a string. Simply shows the compiled assets.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()

--- a/libraries/vendor/jsmin.php
+++ b/libraries/vendor/jsmin.php
@@ -7,14 +7,14 @@
  * </code>
  *
  * This is a modified port of jsmin.c. Improvements:
- * 
+ *
  * Does not choke on some regexp literals containing quote characters. E.g. /'/
- * 
- * Spaces are preserved after some add/sub operators, so they are not mistakenly 
+ *
+ * Spaces are preserved after some add/sub operators, so they are not mistakenly
  * converted to post-inc/dec. E.g. a + ++b -> a+ ++b
  *
  * Preserves multi-line comments that begin with /*!
- * 
+ *
  * PHP 5 or higher is required.
  *
  * Permission is hereby granted to use this version of the library under the
@@ -113,7 +113,7 @@ class JSMin {
             // determine next command
             $command = self::ACTION_KEEP_A; // default
             if ($this->a === ' ') {
-                if (($this->lastByteOut === '+' || $this->lastByteOut === '-') 
+                if (($this->lastByteOut === '+' || $this->lastByteOut === '-')
                     && ($this->b === $this->lastByteOut)) {
                     // Don't delete this space. If we do, the addition/subtraction
                     // could be parsed as a post-increment
@@ -132,7 +132,7 @@ class JSMin {
                 }
             } elseif (! $this->isAlphaNum($this->a)) {
                 if ($this->b === ' '
-                    || ($this->b === "\n" 
+                    || ($this->b === "\n"
                         && (false === strpos('}])+-"\'', $this->a)))) {
                     $command = self::ACTION_DELETE_A_B;
                 }
@@ -154,7 +154,7 @@ class JSMin {
      */
     protected function action($command)
     {
-        if ($command === self::ACTION_DELETE_A_B 
+        if ($command === self::ACTION_DELETE_A_B
             && $this->b === ' '
             && ($this->a === '+' || $this->a === '-')) {
             // Note: we're at an addition/substraction operator; the inputIndex
@@ -168,7 +168,7 @@ class JSMin {
             case self::ACTION_KEEP_A:
                 $this->output .= $this->a;
                 $this->lastByteOut = $this->a;
-                
+
                 // fallthrough
             case self::ACTION_DELETE_A:
                 $this->a = $this->b;
@@ -177,7 +177,7 @@ class JSMin {
                     while (true) {
                         $this->output .= $this->a;
                         $this->lastByteOut = $this->a;
-                        
+
                         $this->a       = $this->get();
                         if ($this->a === $this->b) { // end quote
                             break;
@@ -191,7 +191,7 @@ class JSMin {
                         if ($this->a === '\\') {
                             $this->output .= $this->a;
                             $this->lastByteOut = $this->a;
-                            
+
                             $this->a       = $this->get();
                             $str .= $this->a;
                         }

--- a/libraries/vendor/less.php
+++ b/libraries/vendor/less.php
@@ -17,7 +17,7 @@ use stdClass;
  * The less compiler and parser.
  *
  * Converting LESS to CSS is a two stage process. First the incoming document
- * must be parsed. Parsing creates a tree in memory that represents the 
+ * must be parsed. Parsing creates a tree in memory that represents the
  * structure of the document. Then, the tree of the document is recursively
  * compiled into the CSS text. The compile step has an implicit step called
  * reduction, where values are brought to their lowest form before being
@@ -94,7 +94,7 @@ class lessc {
 		'ms', 's', // Times
 		'Hz', 'kHz', //Frequencies
 	);
-    
+
 	public $importDisabled = false;
 	public $importDir = '';
 
@@ -107,7 +107,7 @@ class lessc {
 	protected $inExp = false;
 
 	/**
-	 * if we are in parens we can be more liberal with whitespace around operators because 
+	 * if we are in parens we can be more liberal with whitespace around operators because
 	 * it must evaluate to a single value and thus is less ambiguous.
 	 *
 	 * Consider:
@@ -144,17 +144,17 @@ class lessc {
 	 * grammatical rules, you can chain them together using &&.
 	 *
 	 * But, if some of the rules in the chain succeed before one fails, then
-	 * the buffer position will be left at an invalid state. In order to 
+	 * the buffer position will be left at an invalid state. In order to
 	 * avoid this, lessc::seek() is used to remember and set buffer positions.
 	 *
 	 * Before parsing a chain, use $s = $this->seek() to remember the current
-	 * position into $s. Then if a chain fails, use $this->seek($s) to 
+	 * position into $s. Then if a chain fails, use $this->seek($s) to
 	 * go back where we started.
 	 */
 	function parseChunk() {
 		if (empty($this->buffer)) return false;
 		$s = $this->seek();
-		
+
 		// setting a property
 		if ($this->keyword($key) && $this->assign() &&
 			$this->propertyValue($value, $key) && $this->end())
@@ -344,12 +344,12 @@ class lessc {
 
 	// a list of expressions
 	function expressionList(&$exps) {
-		$values = array();	
+		$values = array();
 
 		while ($this->expression($exp)) {
 			$values[] = $exp;
 		}
-		
+
 		if (count($values) == 0) return false;
 
 		$exps = $this->compressList($values, ' ');
@@ -443,10 +443,10 @@ class lessc {
 
 	// consume a list of values for a property
 	function propertyValue(&$value, $keyName=null) {
-		$values = array();	
+		$values = array();
 
 		if (!is_null($keyName)) $this->env->currentProperty = $keyName;
-		
+
 		$s = null;
 		while ($this->expressionList($v)) {
 			$values[] = $v;
@@ -467,7 +467,7 @@ class lessc {
 	// a single value
 	function value(&$value) {
 		// try a unit
-		if ($this->unit($value)) return true;	
+		if ($this->unit($value)) return true;
 
 		// see if there is a negation
 		$s = $this->seek();
@@ -489,7 +489,7 @@ class lessc {
 			$this->seek($s);
 		}
 
-		// accessor 
+		// accessor
 		// must be done before color
 		// this needs negation too
 		if ($this->accessor($a)) {
@@ -497,7 +497,7 @@ class lessc {
 			$value = $a;
 			return true;
 		}
-		
+
 		// color
 		if ($this->color($value)) return true;
 
@@ -558,7 +558,7 @@ class lessc {
 
 		// @import "something.css" media;
 		// @import url("something.css") media;
-		// @import url(something.css) media; 
+		// @import url(something.css) media;
 
 		if ($this->literal('url(')) $parens = true; else $parens = false;
 
@@ -634,7 +634,7 @@ class lessc {
 		return true;
 	}
 
-	// a string 
+	// a string
 	function string(&$string, &$d = null) {
 		$s = $this->seek();
 		if ($this->literal('"', false)) {
@@ -649,7 +649,7 @@ class lessc {
 			$this->seek($s);
 			return false;
 		}
-		
+
 		$d = $delim;
 		return true;
 	}
@@ -692,10 +692,10 @@ class lessc {
 
 				$color[$i] = $t * (256/$width) + $t * floor(16/$width);
 			}
-			
+
 			$out = $color;
 			return true;
-		} 
+		}
 
 		return false;
 	}
@@ -713,13 +713,13 @@ class lessc {
 				if ($value == null) $values[] = null;
 				$value = null;
 			}
-		}	
+		}
 
 		if (!$this->literal(')')) {
 			$this->seek($s);
 			return false;
 		}
-		
+
 		$args = $values;
 		return true;
 	}
@@ -909,7 +909,7 @@ class lessc {
 			} else {
 				$name = $this->vPrefix.$name;
 			}
-			return true;	
+			return true;
 		}
 
 		$name = null;
@@ -1003,7 +1003,7 @@ class lessc {
 	}
 
 	function compressList($items, $delim) {
-		if (count($items) == 1) return $items[0];	
+		if (count($items) == 1) return $items[0];
 		else return array('list', $delim, $items);
 	}
 
@@ -1046,7 +1046,7 @@ class lessc {
 	}
 
 	/**
-	 * Recursively compiles a block. 
+	 * Recursively compiles a block.
 	 * @param $block the block
 	 * @param $parentTags the tags of the block that contained this one
 	 *
@@ -1170,7 +1170,7 @@ class lessc {
 					$parts[$i] = str_replace($this->parentSelector, $ptag, $chunk, $c);
 					$count += $c;
 				}
-				
+
 				$tag = implode("&", $parts);
 
 				if ($count > 0) {
@@ -1285,7 +1285,7 @@ class lessc {
 			if (count($path) == 1) {
 				$matches = $this->patternMatchAll($blocks, $args);
 				if (!empty($matches)) {
-					// This will return all blocks that match in the closest 
+					// This will return all blocks that match in the closest
 					// scope that has any matching block, like lessjs
 					return $matches;
 				}
@@ -1434,14 +1434,14 @@ class lessc {
 			// [2] - array of values
 			return implode($value[1], array_map(array($this, 'compileValue'), $value[2]));
 		case 'keyword':
-			// [1] - the keyword 
+			// [1] - the keyword
 		case 'number':
-			// [1] - the number 
+			// [1] - the number
 			return $value[1];
 		case 'escape':
 		case 'string':
 			// [1] - contents of string (includes quotes)
-			
+
 			// search for inline variables to replace
 			$replace = array();
 			if (preg_match_all('/'.$this->preg_quote($this->vPrefix).'\{([\w-_][0-9\w-_]*)\}/', $value[1], $m)) {
@@ -1483,7 +1483,7 @@ class lessc {
 				return $value[1].'('.$this->compileValue($value[2]).')';
 			}
 			else return $this->compileValue($value);
-		default: // assumed to be unit	
+		default: // assumed to be unit
 			return $value[1].$value[0];
 		}
 	}
@@ -1540,7 +1540,7 @@ class lessc {
 			isset($color[4]) ? $color[4]*255 : 0,
 			$color[1],$color[2], $color[3]);
 	}
-	
+
 	function lib_argb($color){
             return $this->lib_rgbahex($color);
         }
@@ -1595,7 +1595,7 @@ class lessc {
 	function lib_floor($arg) {
 		return array($arg[0], floor($arg[1]));
 	}
-	
+
 	function lib_ceil($arg) {
 		return array($arg[0], ceil($arg[1]));
 	}
@@ -1875,7 +1875,7 @@ class lessc {
 				$c = $this->reduce($c);
 				if ($i < 4) {
 					if ($c[0] == '%') $components[] = 255 * ($c[1] / 100);
-					else $components[] = floatval($c[1]); 
+					else $components[] = floatval($c[1]);
 				} elseif ($i == 4) {
 					if ($c[0] == '%') $components[] = 1.0 * ($c[1] / 100);
 					else $components[] = floatval($c[1]);
@@ -1960,7 +1960,7 @@ class lessc {
 				$value = $this->reduce($var[1]);
 				if (is_numeric($value[1])) {
 					$value[1] = -1*$value[1];
-				} 
+				}
 				$var = $value;
 			}
 		}
@@ -2039,7 +2039,7 @@ class lessc {
 			if ($op == '-') $right[1] = '-'.$right[1];
 			return array('keyword', $this->compileValue($left) .' '. $this->compileValue($right));
 		}
-	
+
 		// default to number operation
 		return $this->op_number_number($op, $left, $right);
 	}
@@ -2106,16 +2106,16 @@ class lessc {
 		switch ($op) {
 		case '+':
 			$value = $left[1] + $right[1];
-			break;	
+			break;
 		case '*':
 			$value = $left[1] * $right[1];
-			break;	
+			break;
 		case '-':
 			$value = $left[1] - $right[1];
-			break;	
+			break;
 		case '%':
 			$value = $left[1] % $right[1];
-			break;	
+			break;
 		case '/':
 			if ($right[1] == 0) $this->throwError('parse error: divide by zero');
 			$value = $left[1] / $right[1];
@@ -2152,7 +2152,7 @@ class lessc {
 		$this->env = $b;
 		return $b;
 	}
-	
+
 	// push a block that doesn't multiply tags
 	function pushSpecialBlock($name) {
 		$b = $this->pushBlock(array($name));
@@ -2207,11 +2207,11 @@ class lessc {
 
 		return null;
 	}
-	
+
 	/* raw parsing functions */
 
 	function literal($what, $eatWhitespace = true) {
-		// this is here mainly prevent notice from { } string accessor 
+		// this is here mainly prevent notice from { } string accessor
 		if ($this->count >= strlen($this->buffer)) return false;
 
 		// shortcut on single letter
@@ -2244,7 +2244,7 @@ class lessc {
 		$out = $m[1];
 		return true;
 	}
-	
+
 	// try to match something on head of buffer
 	function match($regex, &$out, $eatWhitespace = true) {
 		$r = '/'.$regex.($eatWhitespace ? '\s*' : '').'/Ais';
@@ -2259,7 +2259,7 @@ class lessc {
 	function peek($regex, &$out = null) {
 		$r = '/'.$regex.'/Ais';
 		$result = preg_match($r, $this->buffer, $out, null, $this->count);
-		
+
 		return $result;
 	}
 
@@ -2330,7 +2330,7 @@ class lessc {
 			$this->set($name, $value);
 		}
 	}
-	
+
 	// parse and compile buffer
 	function parse($str = null, $initial_variables = null) {
 		$locale = setlocale(LC_NUMERIC, 0);
@@ -2370,7 +2370,7 @@ class lessc {
 	 */
 	function __construct($fname = null, $opts = null) {
 		if (!self::$operatorString) {
-			self::$operatorString = 
+			self::$operatorString =
 				'('.implode('|', array_map(array($this, 'preg_quote'),
 					array_keys(self::$precedence))).')';
 		}
@@ -2436,7 +2436,7 @@ class lessc {
 				if ($skip === false) $skip = strlen($text) - $count;
 				else $skip -= $count;
 				break;
-			case '/*': 
+			case '/*':
 				if (preg_match('/\/\*.*?\*\//s', $text, $m, 0, $count)) {
 					$skip = strlen($m[0]);
 					$newlines = substr_count($m[0], "\n");
@@ -2475,20 +2475,20 @@ class lessc {
 
 	/**
 	 * Execute lessphp on a .less file or a lessphp cache structure
-	 * 
+	 *
 	 * The lessphp cache structure contains information about a specific
 	 * less file having been parsed. It can be used as a hint for future
 	 * calls to determine whether or not a rebuild is required.
-	 * 
+	 *
 	 * The cache structure contains two important keys that may be used
 	 * externally:
-	 * 
+	 *
 	 * compiled: The final compiled CSS
 	 * updated: The time (in seconds) the CSS was last compiled
-	 * 
+	 *
 	 * The cache structure is a plain-ol' PHP associative array and can
 	 * be serialized and unserialized without a hitch.
-	 * 
+	 *
 	 * @param mixed $in Input
 	 * @param bool $force Force rebuild?
 	 * @return array lessphp cache structure

--- a/libraries/vendor/urirewriter.php
+++ b/libraries/vendor/urirewriter.php
@@ -1,7 +1,7 @@
 <?php namespace Basset\Vendor;
 
 /**
- * Class Minify_CSS_UriRewriter  
+ * Class Minify_CSS_UriRewriter
  * @package Minify
  */
 
@@ -12,43 +12,43 @@
  * @author Stephen Clay <steve@mrclay.org>
  */
 class URIRewriter {
-    
+
     /**
      * rewrite() and rewriteRelative() append debugging information here
      * @var string
      */
     public static $debugText = '';
-    
+
     /**
      * In CSS content, rewrite file relative URIs as root relative
-     * 
+     *
      * @param string $css
-     * 
+     *
      * @param string $currentDir The directory of the current CSS file.
-     * 
-     * @param string $docRoot The document root of the web site in which 
+     *
+     * @param string $docRoot The document root of the web site in which
      * the CSS file resides (default = $_SERVER['DOCUMENT_ROOT']).
-     * 
-     * @param array $symlinks (default = array()) If the CSS file is stored in 
+     *
+     * @param array $symlinks (default = array()) If the CSS file is stored in
      * a symlink-ed directory, provide an array of link paths to
-     * target paths, where the link paths are within the document root. Because 
-     * paths need to be normalized for this to work, use "//" to substitute 
+     * target paths, where the link paths are within the document root. Because
+     * paths need to be normalized for this to work, use "//" to substitute
      * the doc root in the link paths (the array keys). E.g.:
      * <code>
      * array('//symlink' => '/real/target/path') // unix
      * array('//static' => 'D:\\staticStorage')  // Windows
      * </code>
-     * 
+     *
      * @return string
      */
-    public static function rewrite($css, $currentDir, $docRoot = null, $symlinks = array()) 
+    public static function rewrite($css, $currentDir, $docRoot = null, $symlinks = array())
     {
         self::$_docRoot = self::_realpath(
             $docRoot ? $docRoot : $_SERVER['DOCUMENT_ROOT']
         );
         self::$_currentDir = self::_realpath($currentDir);
         self::$_symlinks = array();
-        
+
         // normalize symlinks
         foreach ($symlinks as $link => $target) {
             $link = ($link === '//')
@@ -57,16 +57,16 @@ class URIRewriter {
             $link = strtr($link, '/', DIRECTORY_SEPARATOR);
             self::$_symlinks[$link] = self::_realpath($target);
         }
-        
+
         self::$debugText .= "docRoot    : " . self::$_docRoot . "\n"
                           . "currentDir : " . self::$_currentDir . "\n";
         if (self::$_symlinks) {
             self::$debugText .= "symlinks : " . var_export(self::$_symlinks, 1) . "\n";
         }
         self::$debugText .= "\n";
-        
+
         $css = self::_trimUrls($css);
-        
+
         // rewrite
         $css = preg_replace_callback('/@import\\s+([\'"])(.*?)[\'"]/'
             ,array(self::$className, '_processUriCB'), $css);
@@ -75,22 +75,22 @@ class URIRewriter {
 
         return $css;
     }
-    
+
     /**
      * In CSS content, prepend a path to relative URIs
-     * 
+     *
      * @param string $css
-     * 
+     *
      * @param string $path The path to prepend.
-     * 
+     *
      * @return string
      */
     public static function prepend($css, $path)
     {
         self::$_prependPath = $path;
-        
+
         $css = self::_trimUrls($css);
-        
+
         // append
         $css = preg_replace_callback('/@import\\s+([\'"])(.*?)[\'"]/'
             ,array(self::$className, '_processUriCB'), $css);
@@ -100,7 +100,7 @@ class URIRewriter {
         self::$_prependPath = null;
         return $css;
     }
-    
+
     /**
      * Get a root relative URI from a file relative URI
      *
@@ -111,7 +111,7 @@ class URIRewriter {
      *     , '/home/user/www'      // doc root
      * );
      * // returns '/img/hello.gif'
-     * 
+     *
      * // example where static files are stored in a symlinked directory
      * Minify_CSS_UriRewriter::rewriteRelative(
      *       'hello.gif'
@@ -121,57 +121,57 @@ class URIRewriter {
      * );
      * // returns '/static/theme/hello.gif'
      * </code>
-     * 
+     *
      * @param string $uri file relative URI
-     * 
+     *
      * @param string $realCurrentDir realpath of the current file's directory.
-     * 
+     *
      * @param string $realDocRoot realpath of the site document root.
-     * 
-     * @param array $symlinks (default = array()) If the file is stored in 
+     *
+     * @param array $symlinks (default = array()) If the file is stored in
      * a symlink-ed directory, provide an array of link paths to
-     * real target paths, where the link paths "appear" to be within the document 
+     * real target paths, where the link paths "appear" to be within the document
      * root. E.g.:
      * <code>
      * array('/home/foo/www/not/real/path' => '/real/target/path') // unix
      * array('C:\\htdocs\\not\\real' => 'D:\\real\\target\\path')  // Windows
      * </code>
-     * 
+     *
      * @return string
      */
     public static function rewriteRelative($uri, $realCurrentDir, $realDocRoot, $symlinks = array())
     {
         // prepend path with current dir separator (OS-independent)
-        $path = strtr($realCurrentDir, '/', DIRECTORY_SEPARATOR)  
+        $path = strtr($realCurrentDir, '/', DIRECTORY_SEPARATOR)
             . DIRECTORY_SEPARATOR . strtr($uri, '/', DIRECTORY_SEPARATOR);
-        
+
         self::$debugText .= "file-relative URI  : {$uri}\n"
                           . "path prepended     : {$path}\n";
-        
+
         // "unresolve" a symlink back to doc root
         foreach ($symlinks as $link => $target) {
             if (0 === strpos($path, $target)) {
                 // replace $target with $link
                 $path = $link . substr($path, strlen($target));
-                
+
                 self::$debugText .= "symlink unresolved : {$path}\n";
-                
+
                 break;
             }
         }
         // strip doc root
         $path = substr($path, strlen($realDocRoot));
-        
+
         self::$debugText .= "docroot stripped   : {$path}\n";
-        
+
         // fix to root-relative URI
 
         $uri = strtr($path, '/\\', '//');
 
         $uri = self::removeDots($uri);
-      
+
         self::$debugText .= "traversals removed : {$uri}\n\n";
-        
+
         return $uri;
     }
 
@@ -189,7 +189,7 @@ class URIRewriter {
         } while ($changed);
         return $uri;
     }
-    
+
     /**
      * Defines which class to call as part of callbacks, change this
      * if you extend Minify_CSS_UriRewriter
@@ -200,9 +200,9 @@ class URIRewriter {
     /**
      * Get realpath with any trailing slash removed. If realpath() fails,
      * just remove the trailing slash.
-     * 
+     *
      * @param string $path
-     * 
+     *
      * @return mixed path with no trailing slash
      */
     protected static function _realpath($path)

--- a/start.php
+++ b/start.php
@@ -4,15 +4,15 @@
  * Register the core libraries and vendor libraries that Basset uses with the autoloader.
  */
 Autoloader::map(array(
-	'Basset'			  		  => __DIR__ . DS . 'libraries' . DS . 'core' . DS . 'basset.php',
-	'Basset\\Asset'				  => __DIR__ . DS . 'libraries' . DS . 'core' . DS . 'asset.php',
-	'Basset\\Cache'				  => __DIR__ . DS . 'libraries' . DS . 'core' . DS . 'cache.php',
-	'Basset\\Config'			  => __DIR__ . DS . 'libraries' . DS . 'core' . DS . 'config.php',
-	'Basset\\Container'			  => __DIR__ . DS . 'libraries' . DS . 'core' . DS . 'container.php',
+	'Basset'                      => __DIR__ . DS . 'libraries' . DS . 'core' . DS . 'basset.php',
+	'Basset\\Asset'               => __DIR__ . DS . 'libraries' . DS . 'core' . DS . 'asset.php',
+	'Basset\\Cache'               => __DIR__ . DS . 'libraries' . DS . 'core' . DS . 'cache.php',
+	'Basset\\Config'              => __DIR__ . DS . 'libraries' . DS . 'core' . DS . 'config.php',
+	'Basset\\Container'           => __DIR__ . DS . 'libraries' . DS . 'core' . DS . 'container.php',
 	'Basset\\Vendor\\CSSCompress' => __DIR__ . DS . 'libraries' . DS . 'vendor' . DS . 'csscompress.php',
-	'Basset\\Vendor\\JSMin'		  => __DIR__ . DS . 'libraries' . DS . 'vendor' . DS . 'jsmin.php',
+	'Basset\\Vendor\\JSMin'       => __DIR__ . DS . 'libraries' . DS . 'vendor' . DS . 'jsmin.php',
+	'Basset\\Vendor\\lessc'       => __DIR__ . DS . 'libraries' . DS . 'vendor' . DS . 'less.php',
 	'Basset\\Vendor\\URIRewriter' => __DIR__ . DS . 'libraries' . DS . 'vendor' . DS . 'urirewriter.php',
-	'Basset\\Vendor\\lessc'		  => __DIR__ . DS . 'libraries' . DS . 'vendor' . DS . 'less.php'
 ));
 
 if(starts_with(URI::current(), Bundle::option('basset', 'handles')))

--- a/tests/basset.test.php
+++ b/tests/basset.test.php
@@ -12,9 +12,12 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 	{
 		Bundle::start('basset');
 
+		// Empty existing routes from the application
+		Basset::$routes = array();
+
 		if(!file_exists(__DIR__ . '/mock'))
 		{
-			mkdir(__DIR__ . '/mock');
+			\Laravel\File::mkdir(__DIR__ . '/mock');
 		}
 	}
 
@@ -27,8 +30,21 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 	{
 		if(file_exists(__DIR__ . '/mock'))
 		{
-			rmdir(__DIR__ . '/mock');
+			\Laravel\File::cleandir(__DIR__ . '/mock');
 		}
+	}
+
+	/**
+	 * Creates a fake stylesheet to use during mocking
+	 *
+	 * @param  string $stylesheet The stylesheet name
+	 * @return array              Path to the created file, its content
+	 */
+	public function createFakeStylesheet($stylesheet = 'mock')
+	{
+		\Laravel\File::put($file = __DIR__ . '/mock/' .$stylesheet. '.css', $contents = 'body { background-color: #ff0000; }');
+
+		return array($file, $contents);
 	}
 
 	/**
@@ -103,7 +119,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testAssetsCanBeCompiled()
 	{
-		file_put_contents($file = __DIR__ . '/mock/mock.css', $contents = 'body { background-color: #ff0000; }');
+		list($file, $contents) = $this->createFakeStylesheet();
 
 		Basset::styles('mock', function($basset)
 		{

--- a/tests/basset.test.php
+++ b/tests/basset.test.php
@@ -108,7 +108,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 	{
 		$container = Basset::inline('mock');
 
-		$this->assertTrue($container === Basset::inline('mock'));
+		$this->assertEquals($container, Basset::inline('mock'));
 		$this->assertArrayHasKey('inline::mock', Basset::$inline);
 	}
 
@@ -137,7 +137,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 		unlink($file);
 
-		$this->assertTrue(trim($compiled) === $contents);
+		$this->assertEquals(trim($compiled), $contents);
 	}
 
 	/**
@@ -151,7 +151,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 		$route = URL::to(Bundle::option('basset', 'handles') . '/mock.css');
 
-		$this->assertTrue(HTML::style($route) === Basset::show('mock.css'));
+		$this->assertEquals(HTML::style($route), Basset::show('mock.css'));
 	}
 
 	/**

--- a/tests/basset.test.php
+++ b/tests/basset.test.php
@@ -5,7 +5,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Starts basset and creates the mock directory. Not ideal but I'm too lazy to try and
 	 * work in a virtual directory system.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function setUp()
@@ -20,7 +20,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * If the mock directory exists we'll delete it in the tear down.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function tearDown()
@@ -33,7 +33,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests that a container can be created.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testContainersCanBeCreated()
@@ -46,7 +46,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests that style routes can be created.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testStyleRoutesCanBeCreated()
@@ -60,7 +60,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests that script routes can be created.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testScriptRoutesCanBeCreated()
@@ -74,7 +74,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests that the routes are created within the Laravel routing system.
-	 * 
+	 *
 	 * @return void
 	 */
 	private function routesCanBeCreated($route)
@@ -85,7 +85,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests that inline containers can be created.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testInlineContainerCanBeCreated()
@@ -98,7 +98,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests that assets are compiled.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testAssetsCanBeCompiled()
@@ -126,7 +126,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests that a Basset URL can be created.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testBassetURLGenerated()
@@ -140,7 +140,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests that assets can be shared.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testAssetsCanBeShared()

--- a/tests/basset.test.php
+++ b/tests/basset.test.php
@@ -19,8 +19,6 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function setUp()
 	{
-		Bundle::start('basset');
-
 		// Empty existing routes
 		Basset::$routes = array();
 
@@ -39,7 +37,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 	{
 		if(file_exists(__DIR__ . '/mock'))
 		{
-			\Laravel\File::cleandir(__DIR__ . '/mock');
+			\Laravel\File::rmdir(__DIR__ . '/mock');
 		}
 	}
 
@@ -173,6 +171,32 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 		Basset::share('mock', 'mock.css');
 
 		$this->assertArrayHasKey('mock', Basset\Container::$shared);
+	}
+
+	public function testAssetsCanBeGloballySetToDevelopment()
+	{
+		list($file,  $contents)  = $this->createFakeStylesheet('foo');
+		list($file2, $contents2) = $this->createFakeStylesheet('bar');
+
+		Config::set('basset::basset.development', true);
+
+		Basset::styles('mock', function($basset)
+		{
+			$basset->directory('path: ' . __DIR__ . '/mock', function($basset)
+			{
+				$basset->add('foo', 'foo.css');
+				$basset->add('bar', 'bar.css');
+			});
+		});
+
+		$expected =
+			"<!-- BASSET NOTICE: Some assets may not be displayed depending on where they were set during the application flow. -->\r\n".
+			'<link href="http://test/foo.css" media="all" type="text/css" rel="stylesheet">'."\r\n\r\n".
+			'<link href="http://test/bar.css" media="all" type="text/css" rel="stylesheet">'."\r\n";
+		$this->assertEquals($expected, Basset::show('mock.css'));
+
+		unlink($file);
+		unlink($file2);
 	}
 
 }

--- a/tests/basset.test.php
+++ b/tests/basset.test.php
@@ -2,6 +2,15 @@
 
 class BassetTest extends PHPUnit_Framework_TestCase {
 
+	public static function setUpBeforeClass()
+	{
+		// Startup Basset
+		Bundle::start('basset');
+
+		// Shorten test domain for easier tests
+		URL::$base = 'http://test/';
+	}
+
 	/**
 	 * Starts basset and creates the mock directory. Not ideal but I'm too lazy to try and
 	 * work in a virtual directory system.
@@ -12,7 +21,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 	{
 		Bundle::start('basset');
 
-		// Empty existing routes from the application
+		// Empty existing routes
 		Basset::$routes = array();
 
 		if(!file_exists(__DIR__ . '/mock'))


### PR DESCRIPTION
This pull request allow the setting of a global `development` option in Basset to avoid, when in local per example, having to set the `development()` mode on each container.

While writing the tests for it I also tweaked the tests a little to make easier the writing of future tests. 
Oh and Sublime also stripped the whitespace in all line endings so disregard that (it's for the best anyway).
