### PR TITLE
Add ability to directly chain methods to a container

### DIFF
--- a/libraries/core/basset.php
+++ b/libraries/core/basset.php
@@ -14,21 +14,21 @@ class Basset {
 
 	/**
 	 * Array of registered route containers.
-	 * 
+	 *
 	 * @var array
 	 */
 	public static $routes = array();
 
 	/**
 	 * Array of registered inline containers.
-	 * 
+	 *
 	 * @var array
 	 */
 	public static $inline = array();
 
 	/**
 	 * Register a new inline container.
-	 * 
+	 *
 	 * @param  string  $name
 	 */
 	public static function inline($name)
@@ -64,14 +64,17 @@ class Basset {
 
 	/**
 	 * Creates a new container to register assets or uses an already existing container.
-	 * 
+	 *
 	 * @param  string   $name
 	 * @param  string   $group
 	 * @param  Closure  $callback
 	 * @return void
 	 */
-	protected static function assets($name, $group, Closure $callback)
+	protected static function assets($name, $group, Closure $callback = null)
 	{
+		// If no callback was passed, mock one
+		if(!$callback) $callback = function() {};
+
 		$route = static::route($name, $group);
 
 		if(!array_key_exists($route, static::$routes))
@@ -80,11 +83,13 @@ class Basset {
 		}
 
 		call_user_func($callback, static::$routes[$route]);
+
+		return static::$routes[$route];
 	}
 
 	/**
 	 * Shares an asset that can be later added without too much typing.
-	 * 
+	 *
 	 * @param  string  $name
 	 * @param  string  $file
 	 * @return void
@@ -96,31 +101,31 @@ class Basset {
 
 	/**
 	 * Generate a scripts route.
-	 * 
+	 *
 	 * @param  string   $name
 	 * @param  Closure  $callback
 	 * @return void
 	 */
-	public static function scripts($name, Closure $callback)
+	public static function scripts($name, Closure $callback = null)
 	{
-		static::assets($name, 'scripts', $callback);
+		return static::assets($name, 'scripts', $callback);
 	}
 
 	/**
 	 * Generate a styles route.
-	 * 
+	 *
 	 * @param  string   $name
 	 * @param  Closure  $callback
 	 * @return void
 	 */
-	public static function styles($name, Closure $callback)
+	public static function styles($name, Closure $callback = null)
 	{
-		static::assets($name, 'styles', $callback);
+		return static::assets($name, 'styles', $callback);
 	}
 
 	/**
 	 * Compiles assets for all registered containers.
-	 * 
+	 *
 	 * @return void
 	 */
 	public static function compile()
@@ -133,7 +138,7 @@ class Basset {
 
 	/**
 	 * Return the compiled output for a given container.
-	 * 
+	 *
 	 * @return string
 	 */
 	public static function compiled()
@@ -160,7 +165,7 @@ class Basset {
 
 	/**
 	 * Return the URL to the asset route container.
-	 * 
+	 *
 	 * @param  string  $route
 	 * @return string
 	 */

--- a/libraries/core/container.php
+++ b/libraries/core/container.php
@@ -10,35 +10,35 @@ class Container {
 
 	/**
 	 * Array of shared assets.
-	 * 
+	 *
 	 * @var array
 	 */
 	public static $shared = array();
 
 	/**
 	 * The route the assets will be display on.
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $route;
 
 	/**
 	 * The group the assets belong to, either scripts or styles.
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $group;
 
 	/**
 	 * The cache object used to store the cached assets.
-	 * 
+	 *
 	 * @var object
 	 */
 	protected $cache;
 
 	/**
 	 * The array containing all the registered assets.
-	 * 
+	 *
 	 * @var array
 	 */
 	protected $assets = array(
@@ -48,21 +48,21 @@ class Container {
 
 	/**
 	 * The current directory to register assets from.
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $directory;
 
 	/**
 	 * The array of registered symlinks.
-	 * 
+	 *
 	 * @var array
 	 */
 	protected $symlinks = array();
 
 	/**
 	 * The array of configuration settings.
-	 * 
+	 *
 	 * @var array
 	 */
 	public $config = array();
@@ -92,8 +92,10 @@ class Container {
 	 * @param  Closure  $callback
 	 * @return object
 	 */
-	public function directory($directory, $callback)
+	public function directory($directory, $callback = null)
 	{
+		if(!$callback) $callback = function() {};
+
 		if(strpos($directory, '::') !== false)
 		{
 			list($bundle, $directory) = explode('::', $directory);
@@ -157,7 +159,7 @@ class Container {
 
 	/**
 	 * Delete an asset from the container.
-	 * 
+	 *
 	 * @param  string  $name
 	 * @return object
 	 */
@@ -265,7 +267,7 @@ class Container {
 
 	/**
 	 * Compiles the scripts for the current container.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function scripts()
@@ -275,7 +277,7 @@ class Container {
 
 	/**
 	 * Compiles the styles for the current container.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function styles()
@@ -285,7 +287,7 @@ class Container {
 
 	/**
 	 * Prepares the assets for compiling.
-	 * 
+	 *
 	 * @param  string  $group
 	 * @return void
 	 */
@@ -419,7 +421,7 @@ class Container {
 
 	/**
 	 * Determines the group to be used.
-	 * 
+	 *
 	 * @return string
 	 */
 	protected function group()
@@ -560,7 +562,7 @@ class Container {
 
 	/**
 	 * Magic method for converting the object to a string. Simply shows the compiled assets.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()

--- a/tests/basset.test.php
+++ b/tests/basset.test.php
@@ -2,38 +2,61 @@
 
 class BassetTest extends PHPUnit_Framework_TestCase {
 
+	public static function setUpBeforeClass()
+	{
+		// Startup Basset
+		Bundle::start('basset');
+
+		// Shorten test domain for easier tests
+		URL::$base = 'http://test/';
+	}
+
 	/**
 	 * Starts basset and creates the mock directory. Not ideal but I'm too lazy to try and
 	 * work in a virtual directory system.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function setUp()
 	{
-		Bundle::start('basset');
+		// Empty existing routes
+		Basset::$routes = array();
 
 		if(!file_exists(__DIR__ . '/mock'))
 		{
-			mkdir(__DIR__ . '/mock');
+			\Laravel\File::mkdir(__DIR__ . '/mock');
 		}
 	}
 
 	/**
 	 * If the mock directory exists we'll delete it in the tear down.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function tearDown()
 	{
 		if(file_exists(__DIR__ . '/mock'))
 		{
-			rmdir(__DIR__ . '/mock');
+			\Laravel\File::rmdir(__DIR__ . '/mock');
 		}
 	}
 
 	/**
+	 * Creates a fake stylesheet to use during mocking
+	 *
+	 * @param  string $stylesheet The stylesheet name
+	 * @return array              Path to the created file, its content
+	 */
+	public function createFakeStylesheet($stylesheet = 'mock')
+	{
+		\Laravel\File::put($file = __DIR__ . '/mock/' .$stylesheet. '.css', $contents = $stylesheet.'body { background-color: #ff0000; }');
+
+		return array($file, $contents);
+	}
+
+	/**
 	 * Tests that a container can be created.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testContainersCanBeCreated()
@@ -46,7 +69,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests that style routes can be created.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testStyleRoutesCanBeCreated()
@@ -60,7 +83,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests that script routes can be created.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testScriptRoutesCanBeCreated()
@@ -74,7 +97,7 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests that the routes are created within the Laravel routing system.
-	 * 
+	 *
 	 * @return void
 	 */
 	private function routesCanBeCreated($route)
@@ -85,25 +108,25 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests that inline containers can be created.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testInlineContainerCanBeCreated()
 	{
 		$container = Basset::inline('mock');
 
-		$this->assertTrue($container === Basset::inline('mock'));
+		$this->assertEquals($container, Basset::inline('mock'));
 		$this->assertArrayHasKey('inline::mock', Basset::$inline);
 	}
 
 	/**
 	 * Tests that assets are compiled.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testAssetsCanBeCompiled()
 	{
-		file_put_contents($file = __DIR__ . '/mock/mock.css', $contents = 'body { background-color: #ff0000; }');
+		list($file, $contents) = $this->createFakeStylesheet();
 
 		Basset::styles('mock', function($basset)
 		{
@@ -121,12 +144,39 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 		unlink($file);
 
-		$this->assertTrue(trim($compiled) === $contents);
+		$this->assertEquals(trim($compiled), $contents);
+	}
+
+	/**
+	 * Tests that assets are compiled.
+	 *
+	 * @return void
+	 */
+	public function testAssetsCanBeAddedInline()
+	{
+		list($file1, $contents1) = $this->createFakeStylesheet('foo');
+		list($file2, $contents2) = $this->createFakeStylesheet('bar');
+
+		$test = Basset::styles('inline')
+			->directory('path: ' . __DIR__ . '/mock')
+			->add('foo', 'foo.css')
+			->add('bar', 'bar.css');
+
+		URI::$uri = Bundle::option('basset', 'handles') . '/inline.css';
+
+		Basset::compile();
+
+		$compiled = Basset::compiled();
+
+		unlink($file1);
+		unlink($file2);
+
+		$this->assertEquals($contents1."\r\n".$contents2, trim($compiled));
 	}
 
 	/**
 	 * Tests that a Basset URL can be created.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testBassetURLGenerated()
@@ -135,12 +185,12 @@ class BassetTest extends PHPUnit_Framework_TestCase {
 
 		$route = URL::to(Bundle::option('basset', 'handles') . '/mock.css');
 
-		$this->assertTrue(HTML::style($route) === Basset::show('mock.css'));
+		$this->assertEquals(HTML::style($route), Basset::show('mock.css'));
 	}
 
 	/**
 	 * Tests that assets can be shared.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function testAssetsCanBeShared()


### PR DESCRIPTION
Sometimes when you just have one or two assets per container it's kind of painful and verbose to have to define a callback just for it. This pull request allows the direct chaining of methods to a given container :

``` php
Basset::styles('styles')
  ->directory('path: ' . 'directory')
  ->add('foo', 'foo.css')
  ->add('bar', 'bar.css');

Basset::scripts('scripts')
  ->add('jquery')
  ->add('scripts', 'scripts.js');
```

I had to report in this PR the modification to the tests made in #49.
