### PR TITLE
Check that pending assets are an array when compiling

### DIFF
--- a/src/Basset/Collection.php
+++ b/src/Basset/Collection.php
@@ -250,6 +250,10 @@ class Collection {
 			// the pending assets of the directory and add them.
 			if ($pending instanceof Directory)
 			{
+				if (!is_array($pending->getPending())) {
+					return;
+				}
+
 				foreach ($pending->getPending() as $asset)
 				{
 					$this->assets[$asset->getGroup()][] = $asset;


### PR DESCRIPTION
This PR checks that the pending assets are an Array.
If a collection is added via "$collection->requireDirectory" but the directory is empty, then the compiler throws an error.
