### PR TITLE
Method for checking if collections are compiled

### DIFF
--- a/src/Basset/Basset.php
+++ b/src/Basset/Basset.php
@@ -158,5 +158,32 @@ class Basset {
 			$this->collection($name, $callback);
 		}
 	}
+	
+	/**
+	 * Check if all collections are compiled
+	 *
+	 * @return bool
+	 */
+	public function isCompiled()
+	{
+		if ($this->collections)
+		{
+			foreach ($this->collections as $collection)
+			{
+				$assets = $collection->getAssets();
+
+				if (isset($assets['style']))
+				{
+					if ( ! $collection->isCompiled('style')) return false;
+				}
+				elseif (isset($assets['script']))
+				{
+					if ( ! $collection->isCompiled('script')) return false;
+				}
+			}
+		}
+
+		return true;
+	}
 
 }


### PR DESCRIPTION
This is useful for a dev environment so that assets are automatically compiled if needed.
This would the look something like this:

``` php
if ( ! Basset::isCompiled())
{
    Artisan::call('basset:compile');
}
```

Maybe in the base controller, or whatever place.
