### PR TITLE
Update to match Laravel's symfony requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "illuminate/http": "4.0.*",
         "illuminate/routing": "4.0.*",
         "illuminate/support": "4.0.*",
-        "symfony/process": "2.2.*",
+        "symfony/process": "2.3.*",
         "kriswallsmith/assetic": "1.1.*@dev"
     },
     "require-dev": {


### PR DESCRIPTION
Currently, using basset and the latest version of Laravel causes a requirement conflict. As of this post, laravel/framework is using Symfony 2.3.\* components, whereas the current develop version of basset in develop requires 2.2.*. 
