### PR TITLE
Fix UriRewriteFilter when building with artisan.

### DIFF
--- a/src/Basset/Filter/UriRewriteFilter.php
+++ b/src/Basset/Filter/UriRewriteFilter.php
@@ -45,7 +45,7 @@ class UriRewriteFilter implements FilterInterface {
      */
     public function __construct($documentRoot = null, $symlinks = array())
     {
-        $this->documentRoot = $this->realPath($documentRoot ?: $_SERVER['DOCUMENT_ROOT']);
+        $this->documentRoot = $this->realPath($documentRoot ?: public_path());
         $this->symlinks = $symlinks;
     }
 


### PR DESCRIPTION
`$_SERVER['DOCUMENT_ROOT']` won't work when using the CLI (e.g. for `artisan basset:build`).

I reckon Laravel's `public_path()` helper is a better option.
