### PR TITLE
Allow arrays to be passed into helper functions

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -9,7 +9,7 @@ if ( ! function_exists('basset_stylesheet'))
      */
     function basset_stylesheet()
     {
-        $collections = array_map(function($collection) { return "{$collection}.css"; }, func_get_args());
+        $collections = array_map(function($collection) { return "{$collection}.css"; }, array_flatten(func_get_args()));
 
         return basset_collections($collections);
     }
@@ -24,7 +24,7 @@ if ( ! function_exists('basset_javascript'))
      */
     function basset_javascript()
     {
-        $collections = array_map(function($collection) { return "{$collection}.js"; }, func_get_args());
+        $collections = array_map(function($collection) { return "{$collection}.js"; }, array_flatten(func_get_args()));
 
         return basset_collections($collections);
     }


### PR DESCRIPTION
Currently `basset_stylesheet` and `basset_javascript` can be passed a number of collections as arguments. It would also be nice to be able to pass in collections of arrays, in case you wanted to make things more dynamic, e.g. setting the collections in the controller. 
