### PR TITLE
Fix 'array_diff_assoc(): Argument #2 is not an array' error.

### DIFF
--- a/src/Basset/Builder/Builder.php
+++ b/src/Basset/Builder/Builder.php
@@ -195,7 +195,7 @@ class Builder {
         // Compute the difference between the collections assets and the manifests assets. If we get
         // an array of values then the collection has changed since the last build and everything
         // should be rebuilt.
-        $difference = array_diff_assoc($manifest, $assets->map(function($asset) { return $asset->getRelativePath(); })->flatten());
+        $difference = array_diff_assoc($manifest, $assets->map(function($asset) { return $asset->getRelativePath(); })->flatten()->toArray());
 
         return ! empty($difference);
     }


### PR DESCRIPTION
I've been having these `array_diff_assoc(): Argument #2 is not an array` errors on development since last `composer update`.

It seems that it's caused by the `$assets->map(...)->flatten()` call [here](https://github.com/laravel/framework/blob/master/src/Illuminate/Support/Collection.php#L264) because it returns another `Illuminate\Support\Collection` object and not an array.

Calling `toArray()` and the end of the call chain fixes the problem.
