### PR TITLE
Skip duplicate asset adding

### DIFF
--- a/src/Basset/Directory.php
+++ b/src/Basset/Directory.php
@@ -98,11 +98,15 @@ class Directory extends Filterable {
     {
         try
         {
-            $asset = $this->assetFactory->make($path = $this->finder->find($name));
+            $path = $this->finder->find($name);
 
-            $asset->isRemote() and $asset->exclude();
+            if(false === isset($this->assets[$path])) {
+                $asset = $this->assetFactory->make($path);
 
-            $this->assets[$path] = $asset;
+                $asset->isRemote() and $asset->exclude();
+
+                $this->assets[$path] = $asset;
+            }
         }
         catch (AssetNotFoundException $e)
         {


### PR DESCRIPTION
Don't know what happened since tomorrow, but again I had problem with assets order (related to closed issue #135).

The problem was in Directory::add(). When the same path was added asset order changed (`$this->assetFactory->make($path)` assignes next order number).

This little fix prevents from making the same asset again.
