### PR TITLE
Remote-only collections are not served

### DIFF
--- a/src/Basset/Server.php
+++ b/src/Basset/Server.php
@@ -131,7 +131,7 @@ class Server {
             {
                 $response = array_merge($response, $this->serveProductionCollection($collection, $entry, $group, $format));
             }
-            elseif ($entry->hasDevelopmentAssets($group))
+            else
             {
                 $response = array_merge($response, $this->serveDevelopmentCollection($collection, $entry, $group, $format));
             }


### PR DESCRIPTION
For a remote-only collection the `Entry` object is completely empty and nothing is served since 5a4aafa3157af4f8fc3d78d61b1a5f6a39300ac3.

This patch fixes it, but i am not sure it is even remotely close to the right way of doing it…

Arthur
