### PR TITLE
Assetic renamed JsMinFilter to JSMinFilter

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -227,9 +227,9 @@ return array(
             |
             */
 
-            'JsMin' => array('JsMinFilter', function($filter)
+            'JsMin' => array('JSMinFilter', function($filter)
             {
-                $filter->whenEnvironmentIs('production', 'prod')->whenClassExists('JsMin');
+                $filter->whenEnvironmentIs('production', 'prod')->whenClassExists('JSMin');
             }),
 
             /*


### PR DESCRIPTION
And the actual JS minifier is called `JSMin`.
The default config doesn't minify the JS currently (it fails with a warning).

Arthur
