### PR TITLE
[Patch] duplicate assets on windows

### DIFF
--- a/src/Basset/Directory.php
+++ b/src/Basset/Directory.php
@@ -99,11 +99,15 @@ class Directory extends Filterable {
         try
         {
             $path = $this->normalizePath($this->finder->find($name));
-            $asset = $this->assetFactory->make($path);
 
-            $asset->isRemote() and $asset->exclude();
+            if ( ! isset($this->assets[$path]))
+            {
+                $asset = $this->assetFactory->make($path);
 
-            $this->assets[$path] = $asset;
+                $asset->isRemote() and $asset->exclude();
+
+                $this->assets[$path] = $asset;
+            }
         }
         catch (AssetNotFoundException $e)
         {

--- a/src/Basset/Directory.php
+++ b/src/Basset/Directory.php
@@ -98,7 +98,7 @@ class Directory extends Filterable {
     {
         try
         {
-            $path = $this->formatPath($this->finder->find($name));
+            $path = $this->normalizePath($this->finder->find($name));
             $asset = $this->assetFactory->make($path);
 
             $asset->isRemote() and $asset->exclude();
@@ -126,7 +126,7 @@ class Directory extends Filterable {
      * @param  string $path
      * @return string
      */
-    private function formatPath($path)
+    private function normalizePath($path)
     {
         return str_replace('\\', '/', $path);
     }

--- a/src/Basset/Directory.php
+++ b/src/Basset/Directory.php
@@ -98,7 +98,8 @@ class Directory extends Filterable {
     {
         try
         {
-            $asset = $this->assetFactory->make($path = $this->finder->find($name));
+            $path = $this->formatPath($this->finder->find($name));
+            $asset = $this->assetFactory->make($path);
 
             $asset->isRemote() and $asset->exclude();
 
@@ -117,6 +118,17 @@ class Directory extends Filterable {
         }
 
         return $this->assets[$path];
+    }
+
+    /**
+     * Format path to UNIX style
+     *
+     * @param  string $path
+     * @return string
+     */
+    private function formatPath($path)
+    {
+        return str_replace('\\', '/', $path);
     }
 
     /**

--- a/tests/Basset/DirectoryTest.php
+++ b/tests/Basset/DirectoryTest.php
@@ -52,6 +52,18 @@ class DirectoryTest extends PHPUnit_Framework_TestCase {
     }
 
 
+    public function testAddingAssetFormatsProperlyPath()
+    {
+        $asset = new Asset($this->files, $this->filter, null, null);
+
+        $this->finder->shouldReceive('find')->once()->with('foo.css')->andReturn('path\to\foo.css');
+        $this->asset->shouldReceive('make')->once()->with('path/to/foo.css')->andReturn($asset);
+
+        $this->assertInstanceOf('Basset\Asset', $this->directory->stylesheet('foo.css'));
+        $this->assertCount(1, $this->directory->getDirectoryAssets());
+    }
+
+
     public function testAddingAssetFiresCallback()
     {
         $asset = new Asset($this->files, $this->filter, null, null);


### PR DESCRIPTION
This PR fixes #135.

Quick, and "dirty" trick to normalize assets paths. I couldn't use `realpath()` for this purpose, so decided to replace `\`  with unix directory separator `/`.

Also during this time one thing happened. My changes from PR #140 were somehow reverted.. I've put them back, because without it occurred some problems with assets order.

Unit test for that would be useful, but for now I don't have enough time to write it :(
