### PR TITLE
Add support for custom filters not in Assetic/Basset namespace

### DIFF
--- a/src/Basset/Filter/Filter.php
+++ b/src/Basset/Filter/Filter.php
@@ -438,7 +438,7 @@ class Filter {
         {
             return "Basset\\Filter\\{$this->filter}";
         }
-        else
+        elseif (class_exists($this->filter))
         {
             return $this->filter;
         }

--- a/src/Basset/Filter/Filter.php
+++ b/src/Basset/Filter/Filter.php
@@ -438,6 +438,10 @@ class Filter {
         {
             return "Basset\\Filter\\{$this->filter}";
         }
+        else
+        {
+            return $this->filter;
+        }
     }
 
     /**


### PR DESCRIPTION
I needed to write a custom filter (for [NgMin](https://github.com/btford/ngmin)) but that doesn't seem to be possible because all filters are expected to be in `Assetic\Filter` or `Basset\Filter` namespaces.
