### PR TITLE
Fix #155 - All assets shared the same filter

### DIFF
--- a/src/Basset/Filter/Filterable.php
+++ b/src/Basset/Filter/Filterable.php
@@ -49,7 +49,7 @@ abstract class Filterable {
             return $this->applyFromArray($filter);
         }
 
-        $filter = $this->factory->get('filter')->make($filter)->setResource($this);
+        $filter = clone $this->factory->get('filter')->make($filter)->setResource($this);
 
         is_callable($callback) and call_user_func($callback, $filter);
 
@@ -66,7 +66,7 @@ abstract class Filterable {
     {
         foreach ($filters as $key => $value)
         {
-            $filter = $this->factory->get('filter')->make(is_callable($value) ? $key : $value)->setResource($this);
+            $filter = clone $this->factory->get('filter')->make(is_callable($value) ? $key : $value)->setResource($this);
 
             is_callable($value) and call_user_func($value, $filter);
 


### PR DESCRIPTION
This was kind of a huge problem : basically if you applied a filter to several assets (a collection, a directory etc), Basset would use the same filter everytime, overwriting the Filter's `resource` property. This pretty much messed up every requirement as the processed requirements of the _last_ asset of the collection would be used for every asset.
