### PR TITLE
Fix the permission on collection.json when building a new file

### DIFF
--- a/src/Basset/Manifest/Manifest.php
+++ b/src/Basset/Manifest/Manifest.php
@@ -158,7 +158,9 @@ class Manifest {
 
             $this->dirty = false;
 
-            return (bool) $this->files->put($path, $this->entries->toJson());
+            $this->files->put($path, $this->entries->toJson());
+            
+            return (bool) chmod($path, 0777);
         }
 
         return false;


### PR DESCRIPTION
## What

After deleting a manifest, when I tried rebuilding it, I would get an error saying permission denied.

![Laravel Error](http://f.cl.ly/items/2t3S3U2X0Y0A0t1O2m1u/Screen-Shot-2013-09-06-at-12.36.20-PM.jpg)
## How

After creating `collection.json` modify permissions on the file to build successfully.

Signed-off-by: Rizwan Iqbal mailme@rizwaniqbal.com
