### PR TITLE
Improved warning message when asset group is determined using cURL

### DIFF
--- a/src/Basset/Asset.php
+++ b/src/Basset/Asset.php
@@ -293,7 +293,7 @@ class Asset extends Filterable {
     {
         if (extension_loaded('curl'))
         {
-            $this->getLogger()->warning('Attempting to determine asset group using cURL. This may have a considerable effect on application speed.');
+            $this->getLogger()->warning("Attempting to determine asset group using cURL because of {$this->absolutePath}. This may have a considerable effect on application speed.");
 
             $handler = curl_init($this->absolutePath);
 


### PR DESCRIPTION
Added to the warning message the filename that is being checked with cURL to determine asset group.
