### PR TITLE
Fixed Directory->except to correctly handle excluded files

### DIFF
--- a/src/Basset/Directory.php
+++ b/src/Basset/Directory.php
@@ -278,8 +278,12 @@ class Directory extends Filterable {
         $this->assets = $this->assets->filter(function($asset) use ($assets, $directory)
         {
             $path = $directory->getPathRelativeToDirectory($asset->getRelativePath());
-
-            return ! in_array($path, $assets);
+            foreach ($assets as $_asset) {
+                if (strpos ($path, $_asset) !== false) {
+                    return false;
+                }
+            }
+            return true;
         });
 
         return $this;


### PR DESCRIPTION
Fixed Directory->except to treat excluded files as patterns since the array assets is relative to the compiled version and not the source version.

This helps to improve performance on https://github.com/andrew13/Laravel-4-Bootstrap-Starter-Site by excluding .jshintrc from compilation

``` php
'public' => function($collection)
{
    $collection->directory('assets/css', function($collection)
    {
        $collection->add('less/master.less')->apply('Less');
    })->apply('UriRewriteFilter')->apply('CssMin');

    $collection->directory('assets/js', function($collection)
    {
        $collection->javascript('jquery/jquery.min.js');
        $collection->add('bootstrap/bootstrap.js');
        $collection->requireDirectory('../../../vendor/twbs/bootstrap/js')->except('.jshintrc');
    })->apply('JsMin');
}
```
