### PR TITLE
Replace deprecated getRemote() from Asset.php

### DIFF
--- a/src/Basset/Asset.php
+++ b/src/Basset/Asset.php
@@ -379,7 +379,7 @@ class Asset extends Filterable {
      */
     public function getContent()
     {
-        return $this->files->getRemote($this->absolutePath);
+        return $this->files->get($this->absolutePath);
     }
 
     /**


### PR DESCRIPTION
The latest build of Laravel removes getRemote(). In my testing, get() works for all my use-cases.
